### PR TITLE
Update opam to support brew

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -179,8 +179,14 @@ depexts: [
         "graphviz"
         "curl"
         "libzip"
-     ]
-    ]
+     ]]
+     [["osx" "brew"] [
+        "gmp"
+        "homebrew/versions/llvm34"
+        "graphviz"
+        "curl"
+        "libzip"
+    ]]
 ]
 
 depopts: [


### PR DESCRIPTION
This is what I believe to be the right settings for building bap with brew. tl;dr, `brew install homebrew/versions/llvm34` worked for me. The other packages are available through brew as is. Didn't test on a fresh install though.
