### PR TITLE
Add IDA brancher and kernel symbols recovery to BAP

### DIFF
--- a/oasis/ida
+++ b/oasis/ida
@@ -18,7 +18,7 @@ Library bap_ida_plugin
   Path:             plugins/ida
   FindlibName:      bap-plugin-ida
   CompiledObject:   best
-  BuildDepends:     bap, bap-ida, cmdliner
+  BuildDepends:     bap, bap-ida, cmdliner, bap-arm
   Modules:          Ida_main
-  InternalModules:  Bap_ida_config, Bap_ida_service
-  XMETADescription: use ida to provide rooter, symbolizer and reconstructor
+  InternalModules:  Bap_ida_config, Bap_ida_service, Ida_ko_symbol_mapper, Ida_commands, Ida_info
+  XMETADescription: use ida to provide brancher, rooter, symbolizer and reconstructor

--- a/plugins/ida/ida_commands.ml
+++ b/plugins/ida/ida_commands.ml
@@ -1,0 +1,49 @@
+open Core_kernel.Std
+open Bap_ida.Std
+open Ida_info
+
+let read_image name =
+  In_channel.with_file name ~f:(fun ch ->
+      Sexp.input_sexp ch |> image_of_sexp)
+
+let load_image =
+  let script =
+    {|
+from bap.utils.ida import dump_loader_info
+dump_loader_info('$output')
+idc.Exit(0)
+|} in
+  Command.create `python
+    ~script
+    ~parser:read_image
+
+let symbolizer_command =
+  let script =
+    {|
+from bap.utils.ida import dump_symbol_info
+dump_symbol_info('$output')
+idc.Exit(0)
+|} in
+  Command.create
+    `python
+    ~script
+    ~parser:(fun name ->
+        let blk_of_sexp x = [%of_sexp:string*int64*int64] x in
+        In_channel.with_file name ~f:(fun ch ->
+            Sexp.input_sexps ch |> List.map ~f:blk_of_sexp))
+
+let brancher_command =
+  let script =
+    {|
+from bap.utils.ida import dump_brancher_info
+dump_brancher_info('$output')
+idc.Exit(0)
+|} in
+  Command.create
+    `python
+    ~script
+    ~parser:(fun name ->
+        let branch_of_sexp x =
+          [%of_sexp: int64 * int64 option * int64 list] x in
+        In_channel.with_file name ~f:(fun ch ->
+            Sexp.input_sexps ch |> List.map ~f:branch_of_sexp))

--- a/plugins/ida/ida_info.ml
+++ b/plugins/ida/ida_info.ml
@@ -1,0 +1,48 @@
+open Core_kernel.Std
+open Regular.Std
+open Bap.Std
+open Format
+
+type perm = [`code | `data] [@@deriving sexp]
+type section = string * perm * int * (int64 * int)
+  [@@deriving sexp]
+
+type image = string * addr_size * section list [@@deriving sexp]
+
+module Img = struct
+  type t = image
+
+  include Data.Make(struct
+      type t = image
+      let version = "0.1"
+    end)
+end
+
+module Symbols = struct
+  type t = (string * int64 * int64) list
+
+  include Data.Make(struct
+      type t = (string * int64 * int64) list
+      let version = "0.1"
+    end)
+end
+
+module Brancher_info = struct
+  type t = (int64 * int64 option * int64 list) list
+
+  include Data.Make(struct
+      type t = (int64 * int64 option * int64 list) list
+      let version = "0.1"
+    end)
+
+  let pp ppf x =
+    List.iter x ~f:(fun (place,dest,rest) ->
+        let s2 = List.fold ~init:" " rest ~f:(fun acc x ->
+            let s = sprintf "0x%x" @@ Int64.to_int_exn x in
+            " "^s^acc) in
+        let s0 = sprintf "0x%x" @@ Int64.to_int_exn place in
+        let s1 = match dest with
+          | Some dest -> sprintf "0x%x" @@ Int64.to_int_exn dest
+          | None -> "" in
+        printf "%s (%s) (%s)@." s0 s1 s2)
+end

--- a/plugins/ida/ida_ko_symbol_mapper.ml
+++ b/plugins/ida/ida_ko_symbol_mapper.ml
@@ -1,0 +1,147 @@
+open Core_kernel.Std
+open Bap.Std
+include Self ()
+open Graphlib.Std
+
+let map_pc_to_dest w relocs =
+  let open Option in
+  List.find_map relocs ~f:(fun (pc,dest) -> some_if (w = pc) (dest))
+  >>= fun dest -> return (Bil.int dest)
+
+class bil_ko_symbol_relocator relocs = object(self)
+  inherit Stmt.mapper as super
+
+  (** If there's a BIL jmp with an address to one of our assembly addresses, in
+      relocs, it currently jumps to itself. We need to update it to jump to the
+      extern functions in the lookup table provided by IDA brancher. We
+      substitute it with [w], our address in the table *)
+  method map_jmp e =
+    let open Option in
+    match e with
+    | Bil.Int w ->
+      map_pc_to_dest w relocs
+      |> Option.value ~default:(Bil.int w)
+      |> super#map_jmp
+    | _ -> super#map_jmp e
+end
+
+module Cfg = struct
+  include Graphs.Cfg
+
+  (** No edge update method? Rolling my own... *)
+  let update_edge cfg e e' = cfg |> Edge.remove e |> Edge.insert e'
+
+  (** use the same label (edge which is `Jump, `Cond, etc) *)
+  let update_dst b cfg e =
+    let src = Edge.src e in
+    let lbl = Edge.label e in
+    let e' = Edge.create src b lbl in
+    update_edge cfg e e'
+
+  let update_src b cfg e =
+    let dst = Edge.dst e in
+    let lbl = Edge.label e in
+    let e' = Edge.create b dst lbl in
+    update_edge cfg e e'
+end
+
+let full_insn_of_mem mem arch =
+  Disasm_expert.Basic.with_disasm ~backend:"llvm" arch
+    ~f:(fun dis ->
+        let open Disasm_expert.Basic in
+        dis |> store_kinds |> store_asm |> fun dis' ->
+        insn_of_mem dis' mem)
+
+let remap_block b memory arch relocs =
+  let bil_remapper = new bil_ko_symbol_relocator relocs in
+  let arch = Arch.to_string arch in
+  (* We need a full_insn type to reconstruct an Insn with an updated
+      bil. So re-disassemble from mem to get the full_insn type *)
+  Block.insns b |> List.map ~f:(fun (mem,insn) ->
+      let bil = Insn.bil insn in
+      let bil' = bil_remapper#run bil in
+      match full_insn_of_mem mem arch with
+      | Ok (_,Some x,_) ->
+        (mem,Insn.of_basic ~bil:bil' x)
+      | _ -> (mem,insn))
+  |> Block.create memory
+
+(** Destructs a disassembly block to instructions, transforms the bil with
+    relocation information in remap_block, and reconstructs / updates edges. *)
+class remap_cfg entry relocs arch = object(self)
+  inherit [block, Graphs.Cfg.edge, block * cfg] Graphlib.dfs_identity_visitor
+  method! enter_node _ b (entry,cfg) =
+    let memory = Block.memory b in
+    let b' = remap_block b memory arch relocs in
+    let ins = Graphs.Cfg.Node.inputs b cfg in
+    let outs = Graphs.Cfg.Node.outputs b cfg in
+    cfg |> Graphs.Cfg.Node.remove b |> Graphs.Cfg.Node.insert b' |> fun cfg' ->
+    Seq.fold ~init:cfg' ins ~f:(Cfg.update_dst b') |> fun cfg' ->
+    Seq.fold ~init:cfg' outs ~f:(Cfg.update_src b') |> fun res ->
+    if Block.addr b' = Block.addr entry then (b',res)
+    else (entry,res)
+end
+
+let remap entry cfg relocs arch =
+  let cfg' = cfg in
+  let visitor = new remap_cfg entry relocs arch in
+  Graphlib.depth_first_visit (module Graphs.Cfg) cfg ~init:(entry,cfg')
+    visitor
+
+(** Brancher introduces synthetic sections (IDA's extern section). The recursive
+    descent disassembler visits this extern section, and under normal operation
+    disassembles bogus hex values. The job of this function is to clean up those
+    extern functions (stub them out) so that they don't contain bogus
+    disassembled instructions. Without this fix-up, the interpreter will get
+    stuck on these instructions which do not return or preserve control flow. *)
+let clean_extern proj entry cfg arch =
+
+  let make_stub mem' arch =
+    match full_insn_of_mem mem' arch with
+    | Ok (_,Some x,_) ->
+      let bil = [Bil.(Jmp (Unknown ("kernel <3", Imm 0)))] in
+      let nop_insn = Insn.of_basic ~bil x in
+      let nop_block = Block.create mem' [mem',nop_insn] in
+      let nop_cfg = Graphs.Cfg.Node.insert nop_block Graphs.Cfg.empty in
+      (nop_block,nop_cfg)
+    | _ ->
+      warning "Failed to disassemble mem for extern function in Ida_ko_mapper.";
+      entry,cfg
+  in
+
+  let memmap = Project.memory proj in
+  Block.memory entry |>
+  Memmap.dominators memmap |>
+  Seq.find_map ~f:(fun (mem,tag) ->
+      match Value.get Image.section tag with
+      | Some "extern" -> Some mem
+      | _ -> None) |> function
+  | Some mem ->
+    (* We need any instruction in a piece of memory which lifts successfully *)
+    let s = Bigstring.of_string "\x00\x00\x00\x00" in
+    let mem' = match Memory.create LittleEndian (Memory.min_addr mem) s with
+      | Ok x -> x
+      (* Note sure when this would fail, but if it does, fail hard. *)
+      | Error e ->
+        let msg = sprintf "Could not create memory in Ida_ko_mapper: %s"
+          @@ Error.to_string_hum e in
+        failwith msg in
+    make_stub mem' (Arch.to_string arch)
+  | None -> entry,cfg
+
+let main proj relocs =
+  let open Option in
+  let open Ida_info in
+  let symtab = Project.symbols proj in
+  (* build a new symtab with remapped ko symbols *)
+  let symtab' =
+    Symtab.to_sequence symtab |>
+    Seq.fold ~init:(Symtab.empty) ~f:(fun acc (fn_name,fn_start_block,fn_cfg) ->
+        (* first, perform relocation *)
+        let fn_start',cfg' =
+          remap fn_start_block fn_cfg relocs (Project.arch proj) in
+        (* now make the function clean if it is in .extern *)
+        let _,cfg' = clean_extern proj fn_start' cfg' (Project.arch proj) in
+        Symtab.add_symbol acc (fn_name,fn_start',cfg')) in
+  Program.lift symtab'
+  |> Project.with_program proj

--- a/plugins/ida/ida_main.ml
+++ b/plugins/ida/ida_main.ml
@@ -4,15 +4,21 @@ open Bap_future.Std
 open Bap.Std
 open Bap_ida.Std
 
-open Format
 open Result.Monad_infix
+
+open Ida_info
+open Ida_commands
 
 include Self()
 
-module Symbols = Data.Make(struct
-    type t = (string * int64 * int64) list
-    let version = "0.1"
-  end)
+module Ida_futures = struct
+  type ('a,'b,'c) t =
+    {symbols : 'a future * 'a promise;
+     brancher : 'b future * 'b promise;
+     img : 'c future * 'c promise} [@@ deriving fields]
+end
+
+open Ida_futures
 
 module type Target = sig
   type t
@@ -22,62 +28,109 @@ module type Target = sig
   end
 end
 
-let get_symbols =
-  Command.create
-    `python
-    ~script:"
-from bap.utils.ida import dump_symbol_info
-dump_symbol_info('$output')
-idc.Exit(0)"
-    ~parser:(fun name ->
-        let blk_of_sexp x = [%of_sexp:string*int64*int64] x in
-        In_channel.with_file name ~f:(fun ch ->
-            Sexp.input_sexps ch |> List.map ~f:blk_of_sexp))
+let addr_of_mem mem =
+  Memory.min_addr mem
+  |> Bitvector.to_int64
+  |> function
+  | Ok addr -> Some addr
+  | Error _ -> None
 
-let extract path arch =
-  let id =
-    Data.Cache.digest ~namespace:"ida" "%s" (Digest.file path) in
+let handle_normal_flow =
+  let (!) = Word.of_int64 ~width:32 in
+  function
+  | Some fall -> [Some !fall, `Fall]
+  | None -> []
+
+(** We have to figure out what the kind is of the other jumps. We use
+    the default Bil brancher: if it has a destination that matches one of
+    ours, then we just use that edge type. If not, we just use jump *)
+let handle_other_flow default rest =
+  let (!) = Word.of_int64 ~width:32 in
+  match rest with
+  | [] -> []
+  | l -> List.fold l ~init:[] ~f:(fun acc dest_addr ->
+      match List.find default ~f:(fun (addr,_) -> addr = Some !dest_addr) with
+      (* If IDA dest addr is in default BIL brancher, use same edge info *)
+      | Some (Some addr,kind) -> (Some !dest_addr, kind)::acc
+      (* XXX heuristic: we are assuming `Jump always (when it could be cond) *)
+      | _ -> (Some !dest_addr, `Jump)::acc)
+
+(** Given a piece of memory and an insn, return a list of destination
+    addrs, and the kind of edge, from this insn. Format:
+    (addr option * [ `Cond | `Fall | `Jump ]) list *)
+let resolve_dests memory insn lookup arch =
+  let open Option in
+  let module Target = (val target_of_arch arch) in
+  addr_of_mem memory >>= fun addr ->
+  (* Only process further if this addr is in our lookup: i.e., we know
+     that we have branch information for it. *)
+  List.find lookup ~f:(fun (needle,_,_) -> needle = addr) >>=
+  (* provide the default information to help with other_flow *)
+  let default_brancher = Brancher.of_bil arch in
+  let default = Brancher.resolve default_brancher memory insn in
+  fun (_,opt,(rest : int64 list)) ->
+    let normal_flow = handle_normal_flow opt in
+    let other_flow = handle_other_flow default rest in
+    other_flow@normal_flow |> return
+
+let read_ida_future_list (future : 'a list future) =
+  match Future.peek future with
+  | Some v -> v
+  | None ->
+    warning "Missing information from IDA";
+    info "This plugin doesn't work with IDA Free";
+    []
+
+(** Brancher is created with (mem → (asm, kinds) insn →
+    (word option * [ `Cond | `Fall | `Jump ]) list) signature *)
+let branch_lookup futures arch path =
+  let open Bil in
+  let id = Data.Cache.digest ~namespace:"ida-brancher"
+      "%s" (Digest.file path) in
+  let lookup = match Brancher_info.Cache.load id with
+    | Some lookup -> lookup
+    | None ->
+      info "Branch lookup: No caching enabled, using futures!";
+      read_ida_future_list (fst futures.brancher)
+  in
+  match lookup with
+  | [] ->
+    warning "didn't find any branches";
+    info "this plugin doesn't work with IDA free";
+    fun mem insn -> []
+  | lookup -> fun mem insn ->
+    match resolve_dests mem insn lookup arch with
+    | None -> []
+    | Some dests -> dests
+
+let register_brancher_source streams =
+  let source =
+    let open Project.Info in
+    let open Option in
+    Stream.merge file arch ~f:(fun file arch ->
+        Or_error.try_with (fun () ->
+            Brancher.create (branch_lookup streams arch file))) in
+  Brancher.Factory.register name source
+
+let extract futures path arch =
+  let id = Data.Cache.digest ~namespace:"ida" "%s" (Digest.file path) in
   let syms = match Symbols.Cache.load id with
     | Some syms -> syms
-    | None -> match Ida.(with_file path get_symbols) with
-      | [] ->
-        warning "didn't find any symbols";
-        info "this plugin doesn't work with IDA Free";
-        []
-      | syms -> Symbols.Cache.save id syms; syms in
+    | None ->
+      info "Extract: No caching enabled, using futures!";
+      read_ida_future_list (fst futures.symbols) in
   let size = Arch.addr_size arch in
   let width = Size.in_bits size in
   let addr = Addr.of_int64 ~width in
-  List.map syms ~f:(fun (n,s,e) -> n, addr s, addr e) |>
-  Seq.of_list
+  List.map syms ~f:(fun (n,s,e) -> n, addr s, addr e)
+  |> Seq.of_list
 
-
-let register_source (module T : Target) =
+let register_source streams (module T : Target) =
   let source =
-    let open Project.Info in
     let extract file arch = Or_error.try_with (fun () ->
-        extract file arch |> T.of_blocks) in
-    Stream.merge file arch ~f:extract in
+        extract streams file arch |> T.of_blocks) in
+    Stream.merge Project.Info.file Project.Info.arch ~f:extract in
   T.Factory.register name source
-
-let loader_script =
-  {|
-from bap.utils.ida import dump_loader_info
-dump_loader_info('$output')
-idc.Exit(0)
-|}
-
-type perm = [`code | `data] [@@deriving sexp]
-type section = string * perm * int * (int64 * int)
-  [@@deriving sexp]
-
-type image = string * addr_size * section list [@@deriving sexp]
-
-module Img = Data.Make(struct
-    type t = image
-    let version = "0.1"
-  end)
-
 
 exception Unsupported_architecture of string
 
@@ -97,15 +150,6 @@ let arch_of_procname size name = match String.lowercase name with
   | "sparcb" -> if size = `r64 then `sparcv9 else `sparc
   | s -> raise (Unsupported_architecture s)
 
-let read_image name =
-  In_channel.with_file name ~f:(fun ch ->
-      Sexp.input_sexp ch |> image_of_sexp)
-
-let load_image = Command.create `python
-    ~script:loader_script
-    ~parser:read_image
-
-
 let mapfile path : Bigstring.t =
   let fd = Unix.(openfile path [O_RDONLY] 0o400) in
   let size = Unix.((fstat fd).st_size) in
@@ -113,31 +157,73 @@ let mapfile path : Bigstring.t =
   Unix.close fd;
   data
 
-let loader path =
-  let id = Data.Cache.digest ~namespace:"ida-loader" "%s"
-      (Digest.file path) in
-  let (proc,size,sections) = match Img.Cache.load id with
+(** For synthetic regions, either match pos against or -1 or name
+    against "extern" *)
+let create_mem pos len endian beg bits size =
+  let addr = Addr.of_int64 ~width:(Size.in_bits size) in
+  match pos with
+  | -1 ->
+    info "Creating synthetic IDA section %s with len %d" name len;
+    Memory.create ~pos:0 ~len endian (addr Int64.(beg - Int64.of_int 0x4)) bits
+  | _ -> Memory.create ~pos ~len endian (addr beg) bits
+
+(** If caching is off, we will always send the info to the future *)
+let preload_ida_info path (futures : ('a,'b,'c) Ida_futures.t) =
+  let preload ~namespace (type t) (module M : Data with type t = t)
+      command field =
+    let id = Data.Cache.digest ~namespace "%s" (Digest.file path) in
+    match M.Cache.load id with
+    | Some _ -> ()
+    | None ->
+      let data = Ida.with_file path command in
+      M.Cache.save id data;
+      Promise.fulfill (snd (Field.get field futures)) data in
+
+  Ida_futures.Fields.iter
+    ~img:(preload ~namespace:"ida-loader" (module Img) load_image)
+    ~symbols:(preload ~namespace:"ida" (module Symbols) symbolizer_command)
+    ~brancher:(preload ~namespace:"ida-brancher"
+                 (module Brancher_info) brancher_command)
+
+let load_image id futures =
+  let read_preloaded_image future =
+    match Future.peek future with
     | Some img -> img
     | None ->
-      let img = Ida.with_file path load_image in
-      Img.Cache.save id img;
-      img in
+      failwith "IDA is enabled with --loader=ida, but no image was preloaded."
+  in
+  match Img.Cache.load id with
+  | Some img -> img
+  | None ->
+    info "Loader: No caching enabled, using futures!";
+    read_preloaded_image (fst futures.img)
+
+let loader (futures : ('a,'b,'c) Ida_futures.t) path =
+  preload_ida_info path futures;
+
+  let id = Data.Cache.digest ~namespace:"ida-loader" "%s" (Digest.file path) in
+  let (proc,size,sections) = load_image id futures in
+
   let bits = mapfile path in
   let arch = arch_of_procname size proc in
   let endian = Arch.endian arch in
-  let addr = Addr.of_int64 ~width:(Size.in_bits size) in
   let code,data = List.fold sections
       ~init:(Memmap.empty,Memmap.empty)
       ~f:(fun (code,data) (name,perm,pos,(beg,len)) ->
-          match Memory.create ~pos ~len endian (addr beg) bits with
+          let mem_or_error = create_mem pos len endian beg bits size in
+          match mem_or_error with
           | Error err ->
             info "skipping section %s: %a" name Error.pp err;
             code,data
           | Ok mem ->
             let sec = Value.create Image.section name in
-            if perm = `code
-            then Memmap.add code mem sec, data
-            else code, Memmap.add data mem sec) in
+            match perm,name with
+            | `code,_ -> Memmap.add code mem sec, data
+            | _,"extern" ->
+              (* Add "extern" mem to code memmap *)
+              let code' = Memmap.add code mem sec in
+              code',data
+            | _ -> code, Memmap.add data mem sec) in
   Project.Input.create arch path ~code ~data
 
 let require req check =
@@ -166,19 +252,77 @@ let checked ida_path is_headless =
        (ida_path/"plugins"/"plugin_loader_bap.py"))  >>| fun () ->
   ida_path
 
+let run_ko_symbol_mapper_pass ida_futures =
+  Project.register_pass ~autorun:true ~name:"ko_symbol_mapper" (fun proj ->
+      match Project.get proj filename with
+      | Some file when String.is_suffix file ".ko" ->
+
+        let id = Data.Cache.digest ~namespace:"ida-brancher"
+            "%s" (Digest.file file) in
+        let lookup = match Brancher_info.Cache.load id with
+          | Some lookup -> lookup
+          | None ->
+            info "Ko_symbol_pass: No caching enabled, using futures!";
+            read_ida_future_list (fst ida_futures.brancher) in
+
+        let simpl_relocs lookup =
+          let (!) = Word.of_int64 ~width:32 in
+          List.fold ~init:[] lookup ~f:(fun acc (addr,_,l) ->
+              match List.hd l with
+              | Some dest -> (!addr,!dest)::acc
+              | None -> acc) in
+
+        let relocs = simpl_relocs lookup in
+        Ida_ko_symbol_mapper.main proj relocs
+      | Some file -> info "Ko_symbol_mapper skipped: no .ko extension";
+        proj
+      | None ->
+        warning "No filename found when attempting ko_symbol_mapper pass";
+        proj)
+
+let load_file path =
+  (* A module to cache filename *)
+  let module Filename = Data.Make(
+    struct type t = string
+      let version = "0.1"
+    end) in
+  match Future.peek path with
+  | Some file ->
+    let id = Data.Cache.digest ~namespace:"ida-filename"
+        "%s" (Digest.string name) in
+    Filename.Cache.save id file;
+    Some file
+  | None ->
+    let id = Data.Cache.digest ~namespace:"ida-filename"
+        "%s" (Digest.string name) in
+    Filename.Cache.load id
 
 let main () =
-  register_source (module Rooter);
-  register_source (module Symbolizer);
-  register_source (module Reconstructor);
-  Project.Input.register_loader name loader
+  let ida_symbols_info,got_ida_symbols_info = Future.create () in
+  let ida_loader_info,got_ida_loader_info = Future.create () in
+  let ida_brancher_info,got_ida_brancher_info = Future.create () in
+
+  let ida_futures =
+    {symbols = (ida_symbols_info, got_ida_symbols_info);
+     img = (ida_loader_info, got_ida_loader_info);
+     brancher = (ida_brancher_info,got_ida_brancher_info)} in
+
+  let loader = loader ida_futures in
+  Project.Input.register_loader name loader;
+
+  register_source ida_futures (module Rooter);
+  register_source ida_futures (module Symbolizer);
+  register_source ida_futures (module Reconstructor);
+  register_brancher_source ida_futures;
+
+  run_ko_symbol_mapper_pass ida_futures
 
 let () =
   let () = Config.manpage [
       `S "DESCRIPTION";
       `P "This plugin provides rooter, symbolizer and reconstuctor services.";
       `P "If IDA instance is found on the machine, or specified by a
-        user, it will be queried for the specified information."
+                 user, it will be queried for the specified information."
     ] in
   let path =
     let doc = "Path to IDA directory." in
@@ -190,5 +334,4 @@ let () =
       match checked !path !headless with
       | Result.Ok path -> Bap_ida_service.register path !headless; main ()
       | Result.Error e -> error "%S. Service not registered."
-                            (Error.to_string_hum e)
-    )
+                            (Error.to_string_hum e))


### PR DESCRIPTION
This PR adds the following:
- IDA brancher. Specify `--brancher=ida` to use IDA's information of
  branch points / jump edges.
- More IDA loader functionality. The `--loader=ida` option will now also
  add IDA's "synthetic" sections to the binary image, such as `extern`.
- Linux kernel module symbols. Kernel symbols are fixed up at runtime.
  To get the symbols statically in BAP, we need a) relocation information
  of which symbols are called at which addresses, and b) to fix up the CFG
  at the callsites to kernel symbols. Part (b) is performed by the
  `ida_ko_symbol_mapper` plugin.
